### PR TITLE
[KC-11] Adds change-frame & playback-controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,38 +20,40 @@
         }
       };
     </script>
-  
+
   <!-- Load polyfills -->
-  <script 
+  <script
     src="node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"
     defer>
-  </script> 
+  </script>
 
   <!-- Load components via WebComponents.waitFor -->
   <script type="module">
-    window.WebComponents = window.WebComponents || { 
+    window.WebComponents = window.WebComponents || {
       waitFor(cb){
         addEventListener('WebComponentsReady', cb)
       }
-    } 
+    }
     WebComponents.waitFor(async () => {
       import('./src/model/store.js');
 
       import('./src/view/kc-webcam.js');
       import('./src/view/kc-timeline.js');
+      import('./src/view/kc-playback-controls.js');
+      import('./src/view/kc-change-frame.js');
       import('./src/view/kc-display.js');
       import('./src/view/kc-transport.js');
-      
+
       import('./src/view/kc-webcam-selector.js');
       import('./src/view/kc-display.js');
       import('./src/view/kc-button.js');
-      
+
       import('./src/action/setup').then((setUp) => {
         setUp.default();
       });
     });
   </script>
-  
+
   <!-- Change stuff here for your app -->
   <meta name="description" content="start-lit-element">
   <meta name="theme-color" content="#ffffff">
@@ -68,5 +70,6 @@
       Could not render the custom element. Check that JavaScript is enabled.
     </noscript>
   </kc-display>
+  <kc-playback-controls></kc-playback-controls>
   <kc-timeline></kc-timeline>
 </body>

--- a/src/view/kc-button.js
+++ b/src/view/kc-button.js
@@ -8,13 +8,14 @@ class KCButton extends LitElement {
 
   static get properties () {
     return {
-      text: { type: String }
+      text: { type: String },
+      title: { type: String }
     }
   }
 
   render () {
     return html`
-    <button id="capture">${this.text}</button>
+      <button title="${this.title || ''}">${this.text}</button>
     `
   }
 }

--- a/src/view/kc-change-frame.js
+++ b/src/view/kc-change-frame.js
@@ -1,0 +1,37 @@
+import { LitElement, html } from 'lit-element';
+
+class KCChangeFrame extends LitElement {
+  static get properties () {
+    return {
+      frameTarget: { type: Number },
+      text: { type: String },
+      title: { type: String }
+    }
+  }
+
+  constructor () {
+    super();
+    this.text = '►►';
+    this.frameTarget = 1;
+    this.title = 'Next'
+  }
+
+  onClick (event) {
+    console.log(this.frameTarget);
+  }
+
+  render () {
+    return html`
+      <kc-button
+        text="${this.text}"
+        title="${this.title}"
+        frametarget="${this.frameTarget}"
+        @click=${this.onClick}>
+      </kc-button>
+    `;
+  }
+}
+
+customElements.define('kc-change-frame', KCChangeFrame);
+
+export default KCChangeFrame;

--- a/src/view/kc-playback-controls.js
+++ b/src/view/kc-playback-controls.js
@@ -1,0 +1,47 @@
+import { LitElement, html } from 'lit-element';
+import { connect } from 'pwa-helpers'
+import { store } from '../model/store.js'
+
+class KCPlaybackControls extends connect(store)(LitElement) {
+  static get properties () {
+    return {
+      frameLength: { type: Number }
+    }
+  }
+
+  render () {
+    return html`
+      <kc-change-frame
+        title="First Frame"
+        frametarget="1"
+        text="▕◀◀">
+      </kc-change-frame>
+
+      <kc-change-frame
+        title="Previous"
+        frametarget="-1"
+        text="◀◀">
+      </kc-change-frame>
+
+      <kc-change-frame
+        title="Next"
+        arget="+1"
+        text="▶▶">
+      </kc-change-frame>
+
+      <kc-change-frame
+        title="End Frame"
+        frametarget="${this.frameLength}"
+        text="▶▶▏">
+      </kc-change-frame>
+    `;
+  }
+
+  stateChanged (state) {
+    this.frameLength = state.timeline.frames.length;
+  }
+}
+
+customElements.define('kc-playback-controls', KCPlaybackControls);
+
+export default KCPlaybackControls;


### PR DESCRIPTION
Note: Prettier is removing white-space and stuff, hope that's cool!

Thought I'd raise a PR now just to get some feedback... I've basically made two components here - `kc-change-frame` and `kc-playback-controls`.

`kc-change-frame` takes a `frameTarget` property, and the intention is that it changes the frame based on the current active frame in the view (`currentIndex`?).

`kc-playback-controls` uses 4 instances of `kc-change-frame` to give us:
- 'First Frame' - `frameTarget` = `1`
- 'Previous' - `frameTarget` = `-1`
- 'Next' - `frameTarget` = `+1`
- 'Last Frame' - `frameTarget` = `state.timeline.frames.length`

The intention is that `kc-playback-controls` holds further components such as Play, Loop, FPS, Fullscreen etc. - it's kinda a wrapper for components which just passes params to them.

I'm console logging the click event handler so you can see the value its returning as an example - hopefully that makes sense.